### PR TITLE
Drop missing 8GB heap

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -761,7 +761,7 @@ CBD_USE_V2 := true
 CBD_PROTOCOL_SIT := true
 
 # setup dalvik vm configs.
-$(call inherit-product, frameworks/native/build/phone-xhdpi-8192-dalvik-heap.mk)
+#$(call inherit-product, frameworks/native/build/phone-xhdpi-8192-dalvik-heap.mk)
 
 PRODUCT_TAGS += dalvik.gc.type-precise
 


### PR DESCRIPTION
Change-Id: I62d425db9ef269a92cd4ff175a25fbab0ba15675
remove it because it make issue when run test dumpvars
device/google/gs101/device.mk:764: error:  frameworks/native/build/phone-xhdpi-8192-dalvik-heap.mk does not exist..