### PR TITLE
Disable CMA migration failure debugging

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -43,7 +43,6 @@ TARGET_2ND_CPU_VARIANT := cortex-a76
 TARGET_2ND_CPU_VARIANT_RUNTIME := cortex-a76
 endif
 
-BOARD_KERNEL_CMDLINE += dyndbg=\"func alloc_contig_dump_pages +p\"
 BOARD_KERNEL_CMDLINE += earlycon=exynos4210,0x10A00000 console=ttySAC0,115200 androidboot.console=ttySAC0 printk.devkmsg=on
 BOARD_KERNEL_CMDLINE += cma_sysfs.experimental=Y
 BOARD_KERNEL_CMDLINE += swiotlb=noforce


### PR DESCRIPTION
This will be useful for Google, but not us, so just disable it to reduce overhead if CMA migration faliures do actually occur.

Change-Id: I3029a00c3d336c6f6ad2468f25735972c5126a14